### PR TITLE
Deps maintenance

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2024.2.3
+        uses: JetBrains/qodana-action@v2024.3.3
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 detekt = "1.23.7"  # Note: Plugin versions must be updated in the settings.gradle.kts too
-kotlin = "2.0.21"  # Note: Plugin versions must be updated in the settings.gradle.kts too
+kotlin = "2.1.0"  # Note: Plugin versions must be updated in the settings.gradle.kts too
 
-groovy = "3.0.22"
+groovy = "3.0.23"
 jansi = "2.4.1"
 kx-ser = "1.7.3"
-logback = "1.5.11"
+logback = "1.5.15"
 logback-groovy = "1.14.5"
-logging = "7.0.0"
+logging = "7.0.3"
 kord-emoji = "0.5.0"
-unleash = "9.2.4"
+unleash = "9.2.6"
 kmongo-coroutine = "5.1.0"
 links-detektor = "1.0.1"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,8 @@
 pluginManagement {
     plugins {
         // Update this in libs.version.toml when you change it here.
-        kotlin("jvm") version "2.0.21"
-        kotlin("plugin.serialization") version "2.0.21"
+        kotlin("jvm") version "2.1.0"
+        kotlin("plugin.serialization") version "2.1.0"
 
         // Update this in libs.version.toml when you change it here.
         id("io.gitlab.arturbosch.detekt") version "1.23.7"
@@ -10,8 +10,17 @@ pluginManagement {
         id("com.github.jakemarsden.git-hooks") version "0.0.2"
         id("com.github.johnrengelman.shadow") version "8.1.1"
 
-        id("dev.kordex.gradle.docker") version "1.4.2"
-        id("dev.kordex.gradle.kordex") version "1.4.2"
+        id("dev.kordex.gradle.docker") version "1.6.0"
+        id("dev.kordex.gradle.kordex") version "1.6.0"
+    }
+
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+
+        maven("https://snapshots-repo.kordex.dev")
+        maven("https://releases-repo.kordex.dev")
+        maven("https://oss.sonatype.org/content/repositories/snapshots")
     }
 }
 


### PR DESCRIPTION
# Description

Dependency upgrades

## Summary by Sourcery

Upgrade dependencies: Kotlin to 2.1.0, Gradle to 8.12, Detekt to 1.23.7, various Kordex libraries to 1.6.0, and other libraries to their latest versions. Update Qodana to 2024.3.3.

Build:
- Upgrade Gradle to version 8.12.

CI:
- Update Qodana GitHub action to 2024.3.3.

Chores:
- Upgrade Kotlin to 2.1.0 and several libraries to their latest versions, including Groovy, Jansi, kotlinx.serialization, Logback, KordEx, Unleash, and KMongo.