### PR TITLE
hotfix - Remove support for phishing-domains check for now

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -10,7 +10,7 @@
   to Kotlin when applicable.
 - The project does not allow warnings or deprecated APIs in the codebase, ensure there are no warnings.
 - Follow the project's coding style and conventions.
-- Try not to use try catch paradigm, Use kotlin alternatives to avoid code smell that comes with try catch.
+- Try not to use try catch paradigm, Use kotlin alternatives to avoid the code smell that comes with try catch.
 - Always check detekt and verify we are passing the lint when we make any change. This **ALWAYS** should be the very last step in the process.
 - Double bangs (!!) are NOT allowed in any condition, Even when a null check is present before using double bang. Always
-  use null checks for defensive programming 
+  use null checks for defensive programming.

--- a/detekt.yml
+++ b/detekt.yml
@@ -32,7 +32,7 @@ console-reports:
 output-reports:
   active: true
   exclude:
-     - 'HtmlOutputReport'
+    - 'HtmlOutputReport'
     # - 'TxtOutputReport'
     # - 'XmlOutputReport'
 
@@ -659,7 +659,7 @@ style:
   UseEmptyCounterpart:
     active: true
   UseIfInsteadOfWhen:
-    active: true
+    active: false
   UseRequire:
     active: true
   UseRequireNotNull:

--- a/src/main/kotlin/troy/commands/funstuff/Dictionary.kt
+++ b/src/main/kotlin/troy/commands/funstuff/Dictionary.kt
@@ -9,7 +9,6 @@ import dev.kordex.core.extensions.publicSlashCommand
 import dev.kordex.core.i18n.toKey
 import dev.kordex.core.utils.env
 import io.ktor.client.call.*
-import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.withTimeoutOrNull
@@ -43,6 +42,7 @@ class Dictionary : Extension() {
                 // Add timeout to HTTP request to prevent hanging
                 val success = withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
                     val result = httpClient.requestAndCatchResponse(
+                        identifier = this@Dictionary.name,
                         block = {
                             get(url) {
                                 headers {

--- a/src/main/kotlin/troy/commands/funstuff/Doggo.kt
+++ b/src/main/kotlin/troy/commands/funstuff/Doggo.kt
@@ -50,6 +50,7 @@ class Doggo : Extension() {
                 // Add timeout to HTTP request to prevent hanging
                 val success = withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
                     val result = httpClient.requestAndCatchResponse(
+                        identifier = this@Doggo.name,
                         block = {
                             doggoModel = get(url).body()
                             true

--- a/src/main/kotlin/troy/commands/funstuff/Fact.kt
+++ b/src/main/kotlin/troy/commands/funstuff/Fact.kt
@@ -33,6 +33,7 @@ class Fact : Extension() {
                 // Add timeout to HTTP request to prevent hanging
                 val success = withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
                     val result = httpClient.requestAndCatchResponse(
+                        identifier = this@Fact.name,
                         block = {
                             factModel = get(FACT_API_URL).body()
                             true

--- a/src/main/kotlin/troy/commands/funstuff/Pun.kt
+++ b/src/main/kotlin/troy/commands/funstuff/Pun.kt
@@ -27,6 +27,7 @@ class Pun : Extension() {
                 // Add timeout to HTTP request to prevent hanging
                 val success = withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
                     val result = httpClient.requestAndCatchResponse(
+                        identifier = this@Pun.name,
                         block = {
                             punsModel = get(PUN_API_URL).body()
                             true

--- a/src/main/kotlin/troy/commands/funstuff/UrbanDictionary.kt
+++ b/src/main/kotlin/troy/commands/funstuff/UrbanDictionary.kt
@@ -9,16 +9,13 @@ import dev.kordex.core.extensions.Extension
 import dev.kordex.core.extensions.publicSlashCommand
 import dev.kordex.core.i18n.toKey
 import io.ktor.client.call.*
-import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.http.*
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.datetime.Clock
 import org.koin.core.component.inject
 import troy.apiModels.UrbanDictItem
 import troy.apiModels.UrbanDictModel
 import troy.utils.*
-import troy.utils.requestAndCatchResponse
 
 class UrbanDictionary : Extension() {
 
@@ -45,6 +42,7 @@ class UrbanDictionary : Extension() {
                 // Add timeout to an HTTP request to prevent hanging
                 val success = withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
                     val result = httpClient.requestAndCatchResponse(
+                        identifier = this@UrbanDictionary.name,
                         block = {
                             urbanDictModel = get("$URBAN_API_URL=$search").body()
                             true

--- a/src/main/kotlin/troy/commands/misc/Steam.kt
+++ b/src/main/kotlin/troy/commands/misc/Steam.kt
@@ -9,8 +9,8 @@ import dev.kordex.core.commands.converters.impl.coalescingString
 import dev.kordex.core.extensions.Extension
 import dev.kordex.core.extensions.publicSlashCommand
 import dev.kordex.core.i18n.toKey
-import io.ktor.client.call.body
-import io.ktor.client.request.get
+import io.ktor.client.call.*
+import io.ktor.client.request.*
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -53,6 +53,7 @@ class Steam : Extension() {
         val url = "https://store.steampowered.com/api/storesearch?cc=us&l=en&term=${gameName.encodeQuery()}"
 
         return httpClient.requestAndCatchResponse(
+            identifier = this@Steam.name,
             block = { get(url).body() },
             notFoundHandler = {
                 respondWithError(dataNotFound)
@@ -76,6 +77,7 @@ class Steam : Extension() {
         val steamGameUrl = "https://store.steampowered.com/api/appdetails?appids=$gameId"
 
         return httpClient.requestAndCatchResponse(
+            identifier = this@Steam.name,
             block = { get(steamGameUrl).body() },
             notFoundHandler = {
                 respondWithError(dataNotFound)

--- a/src/main/kotlin/troy/utils/GreetingsHelper.kt
+++ b/src/main/kotlin/troy/utils/GreetingsHelper.kt
@@ -4,8 +4,8 @@ import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kordex.core.utils.env
 import dev.kordex.core.utils.scheduling.Scheduler
-import io.ktor.client.call.body
-import io.ktor.client.request.get
+import io.ktor.client.call.*
+import io.ktor.client.request.*
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import org.koin.core.component.KoinComponent
@@ -46,6 +46,7 @@ object GreetingsHelper : KoinComponent {
         ayodhyaWeatherUrl: String
     ): OpenWeatherModel? {
         return httpClient.requestAndCatchResponse(
+            identifier = "pollForAyodhyaWeather",
             block = { get(ayodhyaWeatherUrl).body() },
             logPrefix = "Failed to fetch weather data"
         )

--- a/src/main/kotlin/troy/utils/PhishingDomainsHelper.kt
+++ b/src/main/kotlin/troy/utils/PhishingDomainsHelper.kt
@@ -1,18 +1,18 @@
 package troy.utils
 
-import io.ktor.client.call.body
-import io.ktor.client.request.get
 import org.koin.core.component.KoinComponent
-import troy.apiModels.PhishingDomainModel
 
 object PhishingDomainsHelper : KoinComponent {
 
-    private const val DOMAIN_URL = "https://technowolf.in/phishingDomains"
+    fun fetchDomains(): List<String> = emptyList()
 
-    suspend fun fetchDomains(): List<String> {
+//    private const val DOMAIN_URL = "https://technowolf.in/phishingDomains"
+
+    /*suspend fun fetchDomains(): List<String> {
         return httpClient.requestAndCatchResponse(
+            identifier = "fetchPhishingDomains",
             block = { get(DOMAIN_URL).body<PhishingDomainModel>().domains },
             logPrefix = "Failed to fetch phishing domains"
         ) ?: emptyList()
-    }
+    }*/
 }


### PR DESCRIPTION
Disable phishing domain checks for now until upstream API is working correctly

## Summary by Sourcery

Temporarily disable phishing domain checks pending upstream API fix, refactor the HTTP request helper to use runCatching with an explicit identifier and structured success/failure logging, update all call sites to the new helper signature, and apply a minor punctuation fix in the guidelines.

Bug Fixes:
- Temporarily disable phishing domain checks by returning an empty list

Enhancements:
- Refactor HttpClient.requestAndCatchResponse to use runCatching with an identifier parameter and uniform success/failure logging
- Update all extensions and commands to pass the new identifier argument to the request helper

Documentation:
- Fix punctuation in project guidelines regarding code smell and try/catch usage